### PR TITLE
Enable ssl connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 out/
 build/
 .gradle/
+*.iml

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ gradlew.bat jar
 ```
 
 You'll find it in build/libs
+
+# SSL
+Set property `sslenabled=true`
+
+Pass arguments for your keystore and trust store. 
+```
+-Djavax.net.ssl.trustStore=/path/to/client.truststore
+-Djavax.net.ssl.trustStorePassword=password123
+# If you're using client authentication:
+-Djavax.net.ssl.keyStore=/path/to/client.keystore
+-Djavax.net.ssl.keyStorePassword=password123
+```

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
 }
 
-version '1.2.9'
+version '1.3'
 
 sourceCompatibility = 1.8
 

--- a/driver/src/main/java/com/dbschema/CassandraClientURI.java
+++ b/driver/src/main/java/com/dbschema/CassandraClientURI.java
@@ -4,8 +4,11 @@ import com.datastax.driver.core.Cluster;
 
 import java.net.InetAddress;
 import java.util.*;
+import java.util.logging.Logger;
 
 public class CassandraClientURI {
+
+    private static final Logger logger = Logger.getLogger("CassandraClientURILogger");
 
     static final String PREFIX = "jdbc:cassandra://";
 
@@ -15,6 +18,7 @@ public class CassandraClientURI {
     private final String uri;
     private final String userName;
     private final String password;
+    private final Boolean sslEnabled;
 
     public CassandraClientURI(String uri, Properties info) {
         this.uri = uri;
@@ -50,6 +54,9 @@ public class CassandraClientURI {
 
         this.userName = getOption(info, options, "user");
         this.password = getOption(info, options, "password");
+        String sslEnabledOption = getOption(info, options, "sslenabled");
+        this.sslEnabled = sslEnabledOption != null ? Boolean.valueOf(sslEnabledOption) : false;
+
 
         { // userName,password,hosts
             List<String> all = new LinkedList<String>();
@@ -98,6 +105,10 @@ public class CassandraClientURI {
                 host = host.substring( 0, idx ).trim();
             }
             builder.addContactPoints( InetAddress.getByName( host ) );
+            logger.info("sslenabled: " + sslEnabled.toString());
+            if (sslEnabled) {
+                builder.withSSL();
+            }
         }
         if ( port > -1 ){
             builder.withPort( port );
@@ -157,6 +168,15 @@ public class CassandraClientURI {
      */
     public String getPassword() {
         return password;
+    }
+
+    /**
+     * Gets the ssl enabled property
+     *
+     * @return the ssl enabled property
+     */
+    public Boolean getSslEnabled() {
+        return sslEnabled;
     }
 
     /**

--- a/driver/src/test/com/dbschema/CassandraClientURITest.java
+++ b/driver/src/test/com/dbschema/CassandraClientURITest.java
@@ -32,7 +32,7 @@ public class CassandraClientURITest {
 
     @Test
     public void testUriWithUserName() {
-        CassandraClientURI uri = new CassandraClientURI("jdbc:cassandra://localhost:9042/?name=cassandra", null);
+        CassandraClientURI uri = new CassandraClientURI("jdbc:cassandra://localhost:9042/?user=cassandra", null);
         List<String> hosts = uri.getHosts();
         assertEquals(1, hosts.size());
         assertEquals("localhost:9042", hosts.get(0));
@@ -42,15 +42,45 @@ public class CassandraClientURITest {
     @Test
     public void testOptionsInProperties() {
         Properties properties = new Properties();
-        properties.put("name", "NameFromProperties");
+        properties.put("user", "NameFromProperties");
         properties.put("password", "PasswordFromProperties");
         CassandraClientURI uri = new CassandraClientURI(
-                "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra",
+                "jdbc:cassandra://localhost:9042/?user=cassandra&password=cassandra",
                 properties);
         List<String> hosts = uri.getHosts();
         assertEquals(1, hosts.size());
         assertEquals("localhost:9042", hosts.get(0));
         assertEquals("NameFromProperties", uri.getUsername());
         assertEquals("PasswordFromProperties", uri.getPassword());
+    }
+
+
+    @Test
+    public void testSslEnabledOptionTrue() {
+        Properties properties = new Properties();
+        properties.put("sslenabled", "true");
+        CassandraClientURI uri = new CassandraClientURI(
+                "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra",
+                properties);
+        assertTrue(uri.getSslEnabled());
+    }
+
+    @Test
+    public void testSslEnabledOptionFalse() {
+        Properties properties = new Properties();
+        properties.put("sslenabled", "false");
+        CassandraClientURI uri = new CassandraClientURI(
+                "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra",
+                properties);
+        assertFalse(uri.getSslEnabled());
+    }
+
+    @Test
+    public void testNullSslEnabledOptionFalse() {
+        Properties properties = new Properties();
+        CassandraClientURI uri = new CassandraClientURI(
+                "jdbc:cassandra://localhost:9042/?name=cassandra&password=cassandra",
+                properties);
+        assertFalse(uri.getSslEnabled());
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Jan 02 14:25:23 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jan 02 14:25:23 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
For SSL Cassandra clusters this driver is not allowing key store and trust store properties to be used. Please see [DataStax SSL Documentation](https://docs.datastax.com/en/developer/java-driver/3.0/manual/ssl/#driver-configuration).  The cluster builder should be using the withSSL() method if applicable.

This allows you the ability to pass in the JSSE properties as necessary to use SSL.

Tested with Intellij 2018.3 and Datagrip 2018.3